### PR TITLE
Fix entity names to avoid breaking change introduced in Home Assistant 2023.8

### DIFF
--- a/octoprint_homeassistant/__init__.py
+++ b/octoprint_homeassistant/__init__.py
@@ -263,7 +263,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/binary_sensor/" + _node_id + "_CONNECTED/config",
             values={
-                "name": _node_name + " Connected",
+                "name": "Connected",
                 "uniq_id": _node_id + "_CONNECTED",
                 "stat_t": "~" + self._generate_topic("hassTopic", "Connected"),
                 "pl_on": "Connected",
@@ -277,7 +277,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/binary_sensor/" + _node_id + "_PRINTING/config",
             values={
-                "name": _node_name + " Printing",
+                "name": "Printing",
                 "uniq_id": _node_id + "_PRINTING",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "pl_on": "True",
@@ -291,7 +291,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_EVENT/config",
             values={
-                "name": _node_name + " Last Event",
+                "name": "Last event",
                 "uniq_id": _node_id + "_EVENT",
                 "stat_t": "~" + self._generate_topic("eventTopic", "+"),
                 "val_tpl": "{{value_json._event}}",
@@ -303,7 +303,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_S/config",
             values={
-                "name": _node_name + " Print Status",
+                "name": "Print status",
                 "uniq_id": _node_id + "_PRINTING_S",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
@@ -317,7 +317,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_P/config",
             values={
-                "name": _node_name + " Print Progress",
+                "name": "Print progress",
                 "uniq_id": _node_id + "_PRINTING_P",
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_tpl": "{{value_json.progress|tojson}}",
@@ -333,7 +333,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_F/config",
             values={
-                "name": _node_name + " Print File",
+                "name": "Print file",
                 "uniq_id": _node_id + "_PRINTING_F",
                 "stat_t": "~" + self._generate_topic("progressTopic", "printing"),
                 "val_tpl": "{{value_json.path}}",
@@ -346,7 +346,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_T/config",
             values={
-                "name": _node_name + " Print Time",
+                "name": "Print time",
                 "uniq_id": _node_id + "_PRINTING_T",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "avty": [
@@ -369,7 +369,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_E/config",
             values={
-                "name": _node_name + " Print Time Left",
+                "name": "Print time left",
                 "uniq_id": _node_id + "_PRINTING_E",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "avty": [
@@ -392,7 +392,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_ETA/config",
             values={
-                "name": _node_name + " Approximate Total Print Time",
+                "name": "Approximate total print time",
                 "uniq_id": _node_id + "_PRINTING_ETA",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "json_attr_t": "~" + self._generate_topic("hassTopic", "printing"),
@@ -416,7 +416,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_C/config",
             values={
-                "name": _node_name + " Approximate Completion Time",
+                "name": "Approximate completion time",
                 "uniq_id": _node_id + "_PRINTING_C",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "avty": [
@@ -437,7 +437,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_PRINTING_Z/config",
             values={
-                "name": _node_name + " Current Z",
+                "name": "Current Z",
                 "uniq_id": _node_id + "_PRINTING_Z",
                 "stat_t": "~" + self._generate_topic("hassTopic", "printing"),
                 "unit_of_meas": "mm",
@@ -451,7 +451,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_SLICING_P/config",
             values={
-                "name": _node_name + " Slicing Progress",
+                "name": "Slicing progress",
                 "uniq_id": _node_id + "_SLICING_P",
                 "stat_t": "~" + self._generate_topic("progressTopic", "slicing"),
                 "unit_of_meas": "%",
@@ -464,7 +464,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_SLICING_F/config",
             values={
-                "name": _node_name + " Slicing File",
+                "name": "Slicing file",
                 "uniq_id": _node_id + "_SLICING_F",
                 "stat_t": "~" + self._generate_topic("progressTopic", "slicing"),
                 "val_tpl": "{{value_json.source_path}}",
@@ -484,7 +484,7 @@ class HomeassistantPlugin(
                 + str(x)
                 + "/config",
                 values={
-                    "name": _node_name + " Tool " + str(x) + " Temperature",
+                    "name": "Tool " + str(x) + " temperature",
                     "uniq_id": _node_id + "_TOOL" + str(x),
                     "stat_t": "~"
                     + self._generate_topic("temperatureTopic", "tool" + str(x)),
@@ -504,7 +504,7 @@ class HomeassistantPlugin(
                 + "_TARGET"
                 + "/config",
                 values={
-                    "name": _node_name + " Tool " + str(x) + " Target",
+                    "name": "Tool " + str(x) + " target",
                     "uniq_id": _node_id + "_TOOL" + str(x) + "_TARGET",
                     "stat_t": "~"
                     + self._generate_topic("temperatureTopic", "tool" + str(x)),
@@ -520,7 +520,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_BED/config",
             values={
-                "name": _node_name + " Bed Temperature",
+                "name": "Bed temperature",
                 "uniq_id": _node_id + "_BED",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "bed"),
                 "unit_of_meas": "°C",
@@ -533,7 +533,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/sensor/" + _node_id + "_BED_TARGET/config",
             values={
-                "name": _node_name + " Bed Target",
+                "name": "Bed target",
                 "uniq_id": _node_id + "_BED_TARGET",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "bed"),
                 "unit_of_meas": "°C",
@@ -550,7 +550,7 @@ class HomeassistantPlugin(
             self._generate_sensor(
                 topic=_discovery_topic + "/sensor/" + _node_id + "_CHAMBER/config",
                 values={
-                    "name": _node_name + " Chamber Temperature",
+                    "name": "Chamber temperature",
                     "uniq_id": _node_id + "_CHAMBER",
                     "stat_t": "~" + self._generate_topic("temperatureTopic", "chamber"),
                     "unit_of_meas": "°C",
@@ -566,7 +566,7 @@ class HomeassistantPlugin(
                 + _node_id
                 + "_CHAMBER_TARGET/config",
                 values={
-                    "name": _node_name + " Chamber Target",
+                    "name": "Chamber target",
                     "uniq_id": _node_id + "_CHAMBER_TARGET",
                     "stat_t": "~" + self._generate_topic("temperatureTopic", "chamber"),
                     "unit_of_meas": "°C",
@@ -581,7 +581,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic="homeassistant/sensor/" + _node_id + "_SOC/config",
             values={
-                "name": _node_name + " SoC Temperature",
+                "name": "SoC temperature",
                 "uniq_id": _node_id + "_SOC",
                 "stat_t": "~" + self._generate_topic("temperatureTopic", "soc"),
                 "unit_of_meas": "°C",
@@ -880,7 +880,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/switch/" + _node_id + "_CONNECT/config",
             values={
-                "name": _node_name + " Connect to printer",
+                "name": "Connect to printer",
                 "uniq_id": _node_id + "_CONNECT",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "connect"),
                 "stat_t": self._generate_topic("hassTopic", "Connected", full=True),
@@ -903,7 +903,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_STOP/config",
             values={
-                "name": _node_name + " Emergency Stop",
+                "name": "Emergency stop",
                 "uniq_id": _node_id + "_STOP",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "stop"),
                 "device": _config_device,
@@ -921,7 +921,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_CANCEL/config",
             values={
-                "name": _node_name + " Cancel Print",
+                "name": "Cancel print",
                 "uniq_id": _node_id + "_CANCEL",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "cancel"),
                 "avty": [
@@ -946,7 +946,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/switch/" + _node_id + "_PAUSE/config",
             values={
-                "name": _node_name + " Pause Print",
+                "name": "Pause print",
                 "uniq_id": _node_id + "_PAUSE",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "pause"),
                 "stat_t": "~" + self._generate_topic("hassTopic", "is_paused"),
@@ -982,7 +982,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_SHUTDOWN/config",
             values={
-                "name": _node_name + " Shutdown System",
+                "name": "Shutdown system",
                 "uniq_id": _node_id + "_SHUTDOWN",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "shutdown"),
                 "device": _config_device,
@@ -993,7 +993,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_REBOOT/config",
             values={
-                "name": _node_name + " Reboot System",
+                "name": "Reboot system",
                 "uniq_id": _node_id + "_REBOOT",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "reboot"),
                 "device": _config_device,
@@ -1004,7 +1004,7 @@ class HomeassistantPlugin(
         self._generate_sensor(
             topic=_discovery_topic + "/button/" + _node_id + "_RESTART/config",
             values={
-                "name": _node_name + " Restart Server",
+                "name": "Restart server",
                 "uniq_id": _node_id + "_RESTART",
                 "cmd_t": "~" + self._generate_topic("controlTopic", "restart"),
                 "device": _config_device,
@@ -1023,7 +1023,7 @@ class HomeassistantPlugin(
             self._generate_sensor(
                 topic=_discovery_topic + "/switch/" + _node_id + "_PSU/config",
                 values={
-                    "name": _node_name + " PSU",
+                    "name": "PSU",
                     "uniq_id": _node_id + "_PSU",
                     "cmd_t": "~" + self._generate_topic("controlTopic", "psu"),
                     "stat_t": "~" + self._generate_topic("hassTopic", "psu_on"),
@@ -1048,7 +1048,7 @@ class HomeassistantPlugin(
                 + _node_id
                 + "_CAMERA_SNAPSHOT/config",
                 values={
-                    "name": _node_name + " Camera snapshot",
+                    "name": "Camera snapshot",
                     "uniq_id": _node_id + "_CAMERA_SNAPSHOT",
                     "cmd_t": "~"
                     + self._generate_topic("controlTopic", "camera_snapshot"),


### PR DESCRIPTION
A change was implemented in Home Assistant 2023.8 that doesn't allow for entity names to be prefixed by a string that is equivalent to the device name. The device name is OctoPrint. All entity names are currently prefixed with this device name (e.g., OctoPrint Emergency stop). Starting in Home Assistant 2023.8, a warning is logged + repair issue raised for each MQTT entity that is using this naming convention.

Thanks to this pull https://github.com/cmroche/OctoPrint-HomeAssistant/pull/113#issue-1832001908. It can be fixed over here too.